### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/project-board.yml
+++ b/.github/workflows/project-board.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   add-to-project:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Add to GitHub Project


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/1](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/1)

To fix this issue, we should add a `permissions` block to explicitly restrict the permissions for the GITHUB_TOKEN in this workflow. The correct location is either at the top level (applies to all jobs) or within individual jobs. In this case, since there is only one job and CodeQL flagged the job definition, we should add the `permissions` block to the `add-to-project` job or to the root of the workflow. We want to grant only what is strictly needed. For the `actions/add-to-project` action, the minimal necessary permissions are usually `contents: read` (to read repository information) and either `issues: write` or `pull-requests: write` depending on what is added to the project. Since the workflow runs for both `issues` and `pull_request`, we should allow `issues: write` and `pull-requests: write`, but keep everything else read-only.

So either at the workflow root or in the job definition (preferred here for minimal changes), add:

```yaml
permissions:
  contents: read
  issues: write
  pull-requests: write
```

This should be placed directly under `add-to-project:` at the same indentation as `runs-on`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
