### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/2](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/2)

To resolve this issue, set a `permissions` block at the workflow root (global) in `.github/workflows/ci.yml`, immediately after the `name: CI` line (before `on:`), assigning the least required privileges. Since the workflow jobs only check out code and run local commands, they only require read access to `contents`. The correct fix is to add:
```yaml
permissions:
  contents: read
```
directly after `name: CI`. No existing functionality will be changed, and no additional imports or definitions are needed. No jobs in this workflow require finer permissions, so a global block suffices.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
