### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/multimodal-agent-builder/src/main.py
+++ b/multimodal-agent-builder/src/main.py
@@ -32,7 +32,7 @@ async def lifespan(app: FastAPI):
     api_keys = settings.validate_api_keys()
     # Do not log sensitive values!
     if isinstance(api_keys, dict):
-        print(f"API keys present: {list(api_keys.keys())}")
+        print(f"API keys configured: {len(api_keys)}")
     elif isinstance(api_keys, (list, tuple, set)):
         print(f"API keys present: {len(api_keys)} configured.")
     elif isinstance(api_keys, bool):

--- a/multimodal-agent-builder/src/main.py
+++ b/multimodal-agent-builder/src/main.py
@@ -30,7 +30,15 @@ async def lifespan(app: FastAPI):
 
     # Check API keys
     api_keys = settings.validate_api_keys()
-    print(f"API Keys configured: {api_keys}")
+    # Do not log sensitive values!
+    if isinstance(api_keys, dict):
+        print(f"API keys present: {list(api_keys.keys())}")
+    elif isinstance(api_keys, (list, tuple, set)):
+        print(f"API keys present: {len(api_keys)} configured.")
+    elif isinstance(api_keys, bool):
+        print("API keys validated.") if api_keys else print("API key validation failed.")
+    else:
+        print("API keys validation complete.")
 
     yield
 


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/5](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/5)

To fix the problem, avoid logging the actual values of the API keys or any sensitive credential information. Instead, log safer metadata—such as whether all expected keys are present, or simply count how many are configured, or indicate success or failure of validation. In file `multimodal-agent-builder/src/main.py`, in the `lifespan` function, modify line 33 so the sensitive data is not printed. Specifically:
- Replace `print(f"API Keys configured: {api_keys}")` with a statement that only indicates the validation result, e.g., print just the number of keys or a generic confirmation message.
- If `validate_api_keys()` returns a dict of keys, log only the key names (not values).
- If it returns a boolean or similar, log that.
No extra imports nor complex handling are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
