### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,7 @@ async def lifespan(app: FastAPI):
 
     # Check API keys
     api_keys = settings.validate_api_keys()
-    print(f"API Keys configured: {api_keys}")
+    print(f"API Keys successfully configured. ({len(api_keys)} keys)")
 
     yield
 


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/6](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/6)

To fix the clear-text logging of sensitive information, we should avoid logging API keys or secrets, even partially or masked—unless there is a business need and even then only safe metadata should be shown. The best fix is to replace the line logging the value of `api_keys` with a log statement that indicates only safe metadata, such as the number of API keys configured, or just a confirmation that the keys were successfully configured/validated.

Specifically, in `src/main.py`, lines 47-48:
- Do not log the full `api_keys`.
- If safe, log the number of keys (e.g. if `api_keys` is a dict or list).
- Otherwise, simply print a generic message confirming successful configuration.

No new imports are needed.  
No change to the rest of the functionality.  
Edit only lines 47-48 in `src/main.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
