### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/multimodal-agent-builder/run.py
+++ b/multimodal-agent-builder/run.py
@@ -23,10 +23,10 @@ def main():
 
     # Check API keys
     api_keys = settings.validate_api_keys()
-    print("\n🔑 API Key Status:")
-    for provider, configured in api_keys.items():
-        status = "✅" if configured else "❌"
-        print(f"  {status} {provider.capitalize()}")
+    num_providers = len(api_keys)
+    num_configured = sum(1 for configured in api_keys.values() if configured)
+    print(f"\n🔑 API Key Status: {num_configured}/{num_providers} provider(s) configured.")
+
 
     print("\n📡 Server Configuration:")
     print(f"  Host: {settings.app_host}")


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/7](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/7)

To remediate the issue, remove or sanitize the logging of provider names/statuses to ensure no potential sensitive data is printed. The optimal fix is to avoid logging provider names entirely, or to only log a generic message such as "N providers configured", or log a white-listed set of expected provider names (if the set is static and known not to include sensitive values). This change is limited to the block at lines 26–30 in `multimodal-agent-builder/run.py`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
