### PR TITLE
Potential fix for code scanning alert no. 9: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check": "npm run check:ts && eslint ."
   },
   "dependencies": {
-    "express-rate-limit": "^8.1.0"
+    "express-rate-limit": "^8.1.0",
+    "sanitize-html": "^2.17.0"
 }
 }

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -2,7 +2,7 @@ import helmet from 'helmet';
 import crypto from 'crypto';
 import rateLimit from 'express-rate-limit';
 import { Request, Response, NextFunction } from 'express';
-
+import sanitizeHtml from 'sanitize-html';
 // Security headers middleware
 export const securityMiddleware = helmet({
   // Disable Helmet's built-in CSP as we set a dynamic one with nonces below
@@ -106,11 +106,8 @@ export const sanitizeInput = (
   // Recursively sanitize object properties
   const sanitizeObject = (obj: any): any => {
     if (typeof obj === 'string') {
-      // Basic HTML/script tag removal
-      return obj
-        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-        .replace(/<[^>]*>/g, '')
-        .trim();
+      // Robust HTML/script tag removal using sanitize-html
+      return sanitizeHtml(obj, { allowedTags: [], allowedAttributes: {} }).trim();
     }
 
     if (Array.isArray(obj)) {


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/9](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/9)

To fix this issue, we should avoid using brittle regular expressions for HTML sanitization and instead rely on a well-tested, established sanitization library such as DOMPurify or sanitize-html. These libraries thoroughly account for browser quirks and edge cases that regular expressions cannot reliably handle. 

Specifically, within `server/middleware/security.ts`, replace the string sanitization logic in `sanitizeObject` (lines handling script tag and tag removal) with a call to `sanitize-html`, which can clean HTML input according to a customizable policy. This change will ensure that script tags, malformed tags, and potentially dangerous content are robustly filtered.

Steps:
- Import the `sanitize-html` package.
- Replace the string sanitization code inside `sanitizeObject` with a call to `sanitizeHtml`, specifying that no tags (or only a safe whitelist) are allowed.
- No changes to higher-level logic or function signatures.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
