### PR TITLE
Potential fix for code scanning alert no. 10: Bad HTML filtering regexp

### DIFF
--- a/server/services/threatIntelligence.ts
+++ b/server/services/threatIntelligence.ts
@@ -45,7 +45,7 @@ export class ThreatIntelligenceService {
 
     // XSS patterns
     {
-      pattern: /<script[^>]*>.*?<\/script>/i,
+      pattern: /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/i,
       description: 'XSS script injection',
       threatLevel: 'high',
       scoreMultiplier: 2.5,


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/10](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/10)

To improve the regex, we must make the detection robust to extra attributes and whitespace in the closing `</script>` tag. The regex should match any closing tag that starts with `</script`, followed by zero or more non-`>` characters, and then `>`. Additionally, make the regex case-insensitive and global (already the case). The best way is to update the pattern from:  
`/<script[^>]*>.*?<\/script>/i`  
To:  
`/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/i`  
This matches both opening and closing `<script>` tags with optional attributes and whitespace, as browsers do.  
Edit only the code region for the XSS pattern definition in server/services/threatIntelligence.ts (line 48), updating the regex.  
No additional imports or dependencies required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
