### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check": "npm run check:ts && eslint ."
   },
   "dependencies": {
-    "express-rate-limit": "^8.1.0"
+    "express-rate-limit": "^8.1.0",
+    "sanitize-html": "^2.17.0"
 }
 }

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -106,11 +106,16 @@ export const sanitizeInput = (
   // Recursively sanitize object properties
   const sanitizeObject = (obj: any): any => {
     if (typeof obj === 'string') {
-      // Basic HTML/script tag removal
-      return obj
-        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-        .replace(/<[^>]*>/g, '')
-        .trim();
+      // Thoroughly remove all <script>...</script> tags and all other HTML tags in a loop until input is clean
+      let previous;
+      let current = obj;
+      do {
+        previous = current;
+        current = current
+          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+          .replace(/<[^>]*>/g, '');
+      } while (current !== previous);
+      return current.trim();
     }
 
     if (Array.isArray(obj)) {

--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -2,6 +2,7 @@ import helmet from 'helmet';
 import crypto from 'crypto';
 import rateLimit from 'express-rate-limit';
 import { Request, Response, NextFunction } from 'express';
+import sanitizeHtml from 'sanitize-html';
 
 // Security headers middleware
 export const securityMiddleware = helmet({
@@ -106,16 +107,9 @@ export const sanitizeInput = (
   // Recursively sanitize object properties
   const sanitizeObject = (obj: any): any => {
     if (typeof obj === 'string') {
-      // Thoroughly remove all <script>...</script> tags and all other HTML tags in a loop until input is clean
-      let previous;
-      let current = obj;
-      do {
-        previous = current;
-        current = current
-          .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-          .replace(/<[^>]*>/g, '');
-      } while (current !== previous);
-      return current.trim();
+      // Use a well-tested library to strip all script tags and other HTML
+      const clean = sanitizeHtml(obj, { allowedTags: [], allowedAttributes: {} });
+      return clean.trim();
     }
 
     if (Array.isArray(obj)) {


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/11](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/11)

The best way to fix this problem is to ensure that multi-character regular expression removals (such as for `<script>...</script>`) are applied repeatedly until no unsafe pattern is left. For this use-case, refactor the sanitization to apply `.replace()` with the multi-character patterns in a loop until there's no more change—i.e., keep removing script tags and HTML tags until none remain. Alternatively, switching to a well-tested library such as `sanitize-html` is preferable, but since we are constrained to only change code we've seen, and no library imports for sanitization are present, apply the repeated replacement approach.

Edit the recursive sanitization function in `sanitizeInput` (lines 107–131) so that for string values, script tags and all other HTML tags are stripped out in repeated passes until no more instances remain. This can be achieved by creating a loop that applies both regex replaces until stabilization. The rest of the recursive sanitization logic (for arrays and objects) can remain unchanged.

No new imports or external dependencies are required for this fix based on the visible code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
