### PR TITLE
Potential fix for code scanning alert no. 13: Use of externally-controlled format string

### DIFF
--- a/server/services/auditLogger.ts
+++ b/server/services/auditLogger.ts
@@ -47,7 +47,7 @@ class AuditLogger {
       if (success) {
         console.log(logMessage);
       } else {
-        console.error(logMessage, error);
+        console.error("%s", logMessage, error);
       }
 
       // Additional security alerting for critical actions


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/13](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/13)

The best way to fix the problem is to avoid passing potentially untrusted, user-controlled data within the *format string* to a logging function that supports format specifiers (`console.error`, `console.log`, etc.), especially as the only format string argument. Instead, when you have untrusted input, either escape/sanitize it or separate data and format. In this case, the recommended fix is to pass the constructed `logMessage` as a direct value (the format string `"%s"` and the message as one of the parameters), or simply as a single argument (especially in cases where you're also logging an error value, as in `console.error(logMessage, error)`). Alternatively, to ensure no accidental formatting, pass all values as parameters, e.g., `console.error("%s", logMessage, error)`, or merge the error content into the string (using e.g., string concatenation or interpolation).

To minimize impact on existing functionality, and continue to take advantage of `console.error`'s ability to log multiple arguments, the best solution is to pass `logMessage` (the interpolated message) as a string value only (not as a format string) and then the error value, e.g.,
```js
console.error("%s", logMessage, error);
```
This ensures any format specifiers in `logMessage` have no effect.

**Summary of edits:**
- In `server/services/auditLogger.ts`, in the `log` method, update line 50 to use a format string (`"%s"`) and pass `logMessage` as a parameter to `console.error`, along with `error`.
- No changes to the single-argument success path (`console.log(logMessage)`), since in that case, only one argument is passed, so Node prints it verbatim.
- No need for additional imports or helper methods.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
