### PR TITLE
Potential fix for code scanning alert no. 16: Insecure configuration of Helmet security middleware

### DIFF
--- a/server/middleware/security.ts
+++ b/server/middleware/security.ts
@@ -5,8 +5,32 @@ import { Request, Response, NextFunction } from 'express';
 import sanitizeHtml from 'sanitize-html';
 // Security headers middleware
 export const securityMiddleware = helmet({
-  // Disable Helmet's built-in CSP as we set a dynamic one with nonces below
-  contentSecurityPolicy: false,
+  // Enable Helmet's built-in CSP and provide directives using res.locals.cspNonce
+  contentSecurityPolicy: {
+    useDefaults: true,
+    // Nonces provided in res.locals.cspNonce by cspWithNonce middleware
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: [
+        "'self'",
+        // dynamically add nonce for each request
+        (req, res) => `'nonce-${(res.locals as any).cspNonce}'`,
+        ...(process.env.NODE_ENV !== 'production' ? ["'unsafe-inline'"] : []),
+      ],
+      styleSrc: [
+        "'self'",
+        (req, res) => `'nonce-${(res.locals as any).cspNonce}'`,
+        "https://fonts.googleapis.com",
+        ...(process.env.NODE_ENV !== 'production' ? ["'unsafe-inline'"] : []),
+      ],
+      imgSrc: ["'self'", "data:", "https:"],
+      fontSrc: ["'self'", "https://fonts.gstatic.com"],
+      connectSrc: ["'self'", "ws:", "wss:"],
+      frameSrc: ["'none'"],
+      objectSrc: ["'none'"],
+      baseUri: ["'self'"],
+    },
+  },
   crossOriginEmbedderPolicy: false,
   frameguard: { action: 'deny' },
   hsts: {


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/16](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/16)

To fix the problem, ensure that the Helmet security middleware does not disable the `contentSecurityPolicy` feature unless absolutely necessary and unless there is a proven replacement covering all routes. In this situation, since there is a custom CSP middleware (`cspWithNonce`) that sets a per-request, dynamic policy, the best solution is to remove the disabling of `contentSecurityPolicy` from the Helmet configuration and instead configure the Helmet CSP feature to use a function that integrates with the custom nonce logic. This guarantees consistent enforcement and removes the risk of missing routes. Modify the Helmet configuration (lines 7–17) so that it enables the CSP feature and links its directives to the nonce from `res.locals.cspNonce`, allowing the two mechanisms to work together.

Changes:
- Remove or rewrite `contentSecurityPolicy: false` so that Helmet sets CSP based on the per-request nonce.
- If you must continue setting CSP with your custom function, then make sure it is always applied for all requests by integrating it centrally, otherwise use Helmet's native CSP configuration.
- No new imports needed: just use facilities already present in helmet and your per-request nonce.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
