### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -6,6 +6,7 @@ import session from 'express-session';
 import type { Express, RequestHandler } from 'express';
 import memoize from 'memoizee';
 import connectPg from 'connect-pg-simple';
+import rateLimit from 'express-rate-limit';
 import { storage } from './storage';
 import lusca from 'lusca';
 
@@ -76,6 +77,14 @@ async function upsertUser(claims: any) {
 }
 
 export async function setupAuth(app: Express) {
+  // Define a rate limiter for login/auth endpoints
+  const loginRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+    legacyHeaders: false, // Disable the X-RateLimit-* headers
+  });
+
   app.set('trust proxy', 1);
   app.use(getSession());
   app.use(passport.initialize());
@@ -109,21 +118,21 @@ export async function setupAuth(app: Express) {
   passport.serializeUser((user: Express.User, cb) => cb(null, user));
   passport.deserializeUser((user: Express.User, cb) => cb(null, user));
 
-  app.get('/api/login', (req, res, next) => {
+  app.get('/api/login', loginRateLimiter, (req, res, next) => {
     passport.authenticate(`replitauth:${req.hostname}`, {
       prompt: 'login consent',
       scope: ['openid', 'email', 'profile', 'offline_access'],
     })(req, res, next);
   });
 
-  app.get('/api/callback', (req, res, next) => {
+  app.get('/api/callback', loginRateLimiter, (req, res, next) => {
     passport.authenticate(`replitauth:${req.hostname}`, {
       successReturnToOrRedirect: '/',
       failureRedirect: '/api/login',
     })(req, res, next);
   });
 
-  app.get('/api/logout', (req, res) => {
+  app.get('/api/logout', loginRateLimiter, (req, res) => {
     req.logout(() => {
       res.redirect(
         client.buildEndSessionUrl(config, {


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/17](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/17)

To fix this problem, we should apply rate limiting to the sensitive authentication-related endpoints (`/api/login`, `/api/callback`, and possibly `/api/logout`) to prevent automated abuse and denial-of-service. The best and most standard way is to use the popular `express-rate-limit` middleware. At minimum, apply it to `/api/login`, but for completeness and defense-in-depth also apply it to `/api/callback` and `/api/logout`.

The change specifically involves:
- Importing `express-rate-limit` at the top.
- Defining a rate limiter (reasonable default: 100 requests per 15 minutes per IP).
- Applying the rate limiter as middleware to the relevant routes in `setupAuth`.
- Ensure this addition does not interfere with the rest of the logic or session handling.

Apply these changes in `server/replitAuth.ts`:
- Add the import for `express-rate-limit`.
- Define a `loginRateLimiter` (and use same for `/api/callback` and `/api/logout` for consistency).
- Add the limiter as middleware before the route handler functions on lines 112, 119, and 126.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
