### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -6,6 +6,7 @@ import session from 'express-session';
 import type { Express, RequestHandler } from 'express';
 import memoize from 'memoizee';
 import connectPg from 'connect-pg-simple';
+import rateLimit from 'express-rate-limit';
 import { storage } from './storage';
 import lusca from 'lusca';
 
@@ -77,6 +78,13 @@ async function upsertUser(claims: any) {
 
 export async function setupAuth(app: Express) {
   app.set('trust proxy', 1);
+
+  // Rate limiter for auth callback endpoint
+  const authCallbackLimiter = rateLimit({
+    windowMs: 1 * 60 * 1000, // 1 minute
+    max: 5, // limit each IP to 5 requests per windowMs
+    message: 'Too many authentication attempts, please try again later.',
+  });
   app.use(getSession());
   app.use(passport.initialize());
   app.use(passport.session());
@@ -116,7 +124,7 @@ export async function setupAuth(app: Express) {
     })(req, res, next);
   });
 
-  app.get('/api/callback', (req, res, next) => {
+  app.get('/api/callback', authCallbackLimiter, (req, res, next) => {
     passport.authenticate(`replitauth:${req.hostname}`, {
       successReturnToOrRedirect: '/',
       failureRedirect: '/api/login',


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/18](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/18)

To fix the missing rate limiting error on the `/api/callback` endpoint in `server/replitAuth.ts`, we should add a rate limiting middleware to this route. The recommended approach is to use the well-known `express-rate-limit` package. This addition will specifically restrict how frequently users (typically by IP) can access this endpoint, mitigating the risk of abuse/output flooding. The steps are:

1. Import `express-rate-limit` at the top of the file.
2. Define a rate limiter suitable for authentication callback routes (for example, 5 requests per minute per IP).
3. Apply the rate limiter middleware to the `/api/callback` route: add it as the first argument in the route definition.
No changes to the authentication flow or existing functionality are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
