### PR TITLE
Potential fix for code scanning alert no. 19: Missing rate limiting

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -27,6 +27,14 @@ export async function setupVite(app: Express, server: Server) {
     allowedHosts: true,
   };
 
+  // Limit requests to expensive Vite HTML transform route
+  const viteHtmlRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
+
   const vite = await createViteServer({
     ...viteConfig,
     configFile: false,
@@ -42,7 +50,7 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  app.use('*', async (req, res, next) => {
+  app.use('*', viteHtmlRateLimiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/19](https://github.com/anumethod/multimodal-agent-builder/security/code-scanning/19)

To mitigate the lack of rate limiting for expensive file system accesses in the fallback GET handler (starting line 45), we should use the `express-rate-limit` middleware in the `setupVite` function as well as in `serveStatic`.  
The best fix is to construct a rate limiter (using the already-imported `express-rate-limit` package), and apply it specifically to the wildcard (`'*'`) handler in `setupVite`, just as is done within `serveStatic`.  
- Define a rate limiter configuration (it can be the same or separate as the one in `serveStatic`, for clarity and possible future configurability).
- Instantiate the rate limiter within `setupVite`.
- Apply the rate limiter to the `app.use('*', ...)` handler before the handler function, so it takes effect on all incoming requests to this route.
- No existing behavior will be affected, except for enforcing request limits, and there is no need to change any functionality beyond protecting the expensive route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
